### PR TITLE
Allow to show all uploads (not just 15 - as in pagination) in markdown image browser

### DIFF
--- a/app/controllers/spree/admin/uploads_controller.rb
+++ b/app/controllers/spree/admin/uploads_controller.rb
@@ -1,8 +1,11 @@
 class Spree::Admin::UploadsController < Spree::Admin::ResourceController
   
 	def index
+	  if request.xhr?
+	    @uploads = Spree::Upload.all
+	  end
 	  render :template => "spree/admin/uploads/#{request.xhr? ? 'picker' : 'index'}", :layout => !request.xhr?
-  end
+  	end
   
   private
   


### PR DESCRIPTION
Hi!

I've made a small hack to allow to show all uploads (not just ex. 15 - as in pagination limit) in markdown image browser

hope it will be useful :-)
