### PR TITLE
Update dependency to spree_core 1.2.0

### DIFF
--- a/spree_essentials.gemspec
+++ b/spree_essentials.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency('spree_core',  '~> 1.1.0')
+  s.add_runtime_dependency('spree_core',  '~> 1.2.0')
   s.add_runtime_dependency('rdiscount',   '~> 1.6.8')
 
   s.add_development_dependency('shoulda',      '~> 3.0.0')


### PR DESCRIPTION
Probably, separate branches should be created for 1-2-stable and 1-3 stable
